### PR TITLE
remove extra colon - click already generates the colon and space

### DIFF
--- a/dinopass/cli.py
+++ b/dinopass/cli.py
@@ -15,7 +15,7 @@ SALT_LENGTH = 16
 
 def set_context_master_password_exists(ctx, master_password_view, password_view):
     master_password = click.prompt(
-        'Please enter your master password: ',
+        'Please enter your master password',
         hide_input=True
     )
 
@@ -34,7 +34,7 @@ def set_context_master_password_does_not_exist(ctx, master_password_view, passwo
                      f'Would you like to create one now?', abort=True):
 
         master_password = click.prompt(
-            'Please enter your master password: ',
+            'Please enter your master password',
             hide_input=True
         )
 


### PR DESCRIPTION
This is a cool little tool. It looks like there's an extra colon and space on the master password prompt since `click` already provides a colon and space.
<img width="449" alt="Screen Shot 2020-11-16 at 4 01 12 PM" src="https://user-images.githubusercontent.com/14168559/99322528-f6d4b180-2824-11eb-9a80-b8c9b13db094.png">
This PR should fix that. 